### PR TITLE
created profile picture component

### DIFF
--- a/ui/app/components/profilePicture.js
+++ b/ui/app/components/profilePicture.js
@@ -1,0 +1,32 @@
+import { Avatar, Image } from "antd";
+import styles from "../stylesheets/profilePicture.module.css";
+import { UserOutlined } from "@ant-design/icons";
+
+export default function ReplaceWithComponentName({ size, url }) {
+  let width = 200;
+  switch (size) {
+    case "small":
+      width = 50;
+      break;
+    case "medium":
+      width = 150;
+      break;
+    case "large":
+      width = 250;
+      break;
+    default:
+      break;
+  }
+  if (url) {
+    return (
+      <Image
+        className={styles.round}
+        width={width}
+        alt="Profile Picture"
+        src={url}
+      />
+    );
+  } else {
+    return <Avatar size={width} icon={<UserOutlined />} />;
+  }
+}

--- a/ui/app/stylesheets/profilePicture.module.css
+++ b/ui/app/stylesheets/profilePicture.module.css
@@ -1,0 +1,3 @@
+.round {
+  border-radius: 50%;
+}


### PR DESCRIPTION
# trello
[ticket](https://trello.com/c/FPzbo9Sm)

## description
Added a profile picture component
props:
- size: controls the width and height of the profile picture. accepts "small", "medium", "large"
- url: the link to the picture, if no url is provided, then a placeholder is used
## screenshots
<img width="289" height="204" alt="Screenshot 2025-08-17 at 1 57 56 PM" src="https://github.com/user-attachments/assets/8d767749-a5f4-415b-90bb-b77ec1ab05bc" />
<img width="333" height="208" alt="Screenshot 2025-08-17 at 2 00 43 PM" src="https://github.com/user-attachments/assets/ddbe06fd-0510-44ce-b1d2-256e121043be" />
